### PR TITLE
Fix Render deployment by updating build scripts and server config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "pnpm build:client && pnpm build:server && pnpm copy:templates",
     "build:client": "vite build",
     "copy:templates": "mkdir -p dist/email-templates && cp -r src/email-templates/* dist/email-templates/ || true",
     "build:server": "vite build --config vite.config.server.ts",

--- a/vite.config.server.ts
+++ b/vite.config.server.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, "server/node-build.ts"),
       name: "server",
-      fileName: "production",
       formats: ["es"],
     },
     outDir: "dist/server",


### PR DESCRIPTION
## Purpose
Fix deployment error on Render where the application was failing to start due to missing server build file. The user was encountering a "Cannot find module '/opt/render/project/src/dist/server/node-build.mjs'" error during deployment, preventing the application from running in production.

## Code changes
- **package.json**: Updated the main `build` script to run client build, server build, and template copying in sequence instead of just running client build
- **vite.config.server.ts**: Removed the `fileName: "production"` configuration to use the default filename generation, ensuring the server build outputs to the expected `node-build.mjs` file location

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef6576d0b9c14a339c7abf7aaa4e6f41/curry-haven)

👀 [Preview Link](https://ef6576d0b9c14a339c7abf7aaa4e6f41-curry-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef6576d0b9c14a339c7abf7aaa4e6f41</projectId>-->
<!--<branchName>curry-haven</branchName>-->